### PR TITLE
Fix Linguist language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-static/*.css linguist-detectable=false
+static/css/*.css linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+static/*.css linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-static/css/*.css linguist-detectable=false
+static/css/*.* linguist-detectable=false


### PR DESCRIPTION
Because GitHub detects the repository language as CSS, I just added .gitattributes to override the language to Python.