### PR TITLE
updated "pid" to match most recent qbittorrent peerID

### DIFF
--- a/newTrackon/scraper.py
+++ b/newTrackon/scraper.py
@@ -191,7 +191,7 @@ def get_bep_34(hostname):
 
 def announce_http(url, thash=urandom(20)):
     logger.info(f"{url} Scraping HTTP(S)")
-    pid = "-qB3360-" + "".join(
+    pid = "-qB4390-" + "".join(
         [random.choice(string.ascii_letters + string.digits) for _ in range(12)]
     )
 


### PR DESCRIPTION
helps with trackers that are updating whitelists etc.

maybe would be better to use something that's more widely accepted such as Deluge 1.3.15? `DE13F0`

I'll leave that decision to you, thanks for your time!