### PR TITLE
Remove LGTM badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # newTrackon
 
 [![Requirements Status](https://requires.io/github/CorralPeltzer/newTrackon/requirements.svg?branch=master)](https://requires.io/github/CorralPeltzer/newTrackon/requirements/?branch=master)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/CorralPeltzer/newTrackon.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/CorralPeltzer/newTrackon/context:python)
 
 newTrackon is a service to monitor the status and health of existing open and public trackers that anyone can use. It
 also allows to submit new trackers to add them to the list.


### PR DESCRIPTION
It's being deprecated, will stop working in December: https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/