### PR TITLE
Fix BEP34 bad parsing, fixes #294

### DIFF
--- a/newTrackon/scraper.py
+++ b/newTrackon/scraper.py
@@ -183,7 +183,7 @@ def get_bep_34(hostname):
     try:
         txt_info = resolver.resolve(hostname, "TXT").response.answer[0]
         for record in txt_info:
-            record_text = str(record)
+            record_text = str(record).strip('\"')
             if record_text.startswith("BITTORRENT"):
                 return True, process_txt_prefs(record_text)
     except DNSException:


### PR DESCRIPTION
### Description

Currently, there’s a bug that some people have reported regarding BP34 processing, which makes the system completely ignore whatever is in the DNS record.
This happens because the DNS resolve response returns the contents of the record wrapped in double quotes. As a result, the content string never starts with `BITTORRENT` since the first character is `"`, and proceeds tracking the tracker.

For example, the record text `example.com. 300 IN TXT "BITTORRENT"` is parsed as `"BITTORRENT"`, which is interpreted as not valid according to BEP34 rules.

Just removing trailing quotes will fix the problem.

### Affects

- The consideration of BEP34 when adding a tracker.
- The ability to remove a tracker (for example, if the URL has changed and the user wants to update it) by adding a BEP34 record without preferences.

Both of these issues are mentioned on the webpage in the FAQ section regarding tracker management, but currently, this information is not true.
